### PR TITLE
Request Encoding and MediaType as optional Parameters

### DIFF
--- a/src/FinalRest.core/BuilderExtensions/Request/FinalRequestBuilderExtensionsBase.cs
+++ b/src/FinalRest.core/BuilderExtensions/Request/FinalRequestBuilderExtensionsBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace FinalRest.core
@@ -49,11 +50,14 @@ namespace FinalRest.core
         /// <param name="self">The Builder as extended Method</param>
         /// <param name="method">The Rest Method used for this Request</param>
         /// <returns>The Builder for chaining methods</returns>
-        public static FinalRestRequestBuilder SetMethod(this FinalRestRequestBuilder self, ERestMethod method)
+        public static FinalRestRequestBuilder SetMethod(this FinalRestRequestBuilder self, ERestMethod method, Encoding encoding = null, string mediaType = null)
         {
             self.Method = method;
+            self.Encoding = encoding;
+            self.MediaType = mediaType;
             return self;
         }
+
         /// <summary>
         /// Sets the used Content-Type of a post request
         /// </summary>

--- a/src/FinalRest.core/BuilderExtensions/Request/FinalRequestBuilderExtensionsBuild.cs
+++ b/src/FinalRest.core/BuilderExtensions/Request/FinalRequestBuilderExtensionsBuild.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace FinalRest.core
@@ -26,6 +27,8 @@ namespace FinalRest.core
             return new FinalRestRequest
             {
                 Method = self.Method != ERestMethod.Default ? self.Method : ERestMethod.GET,
+                Encoding = self.Encoding ?? Encoding.UTF8,
+                MediaType = self.MediaType ?? "application/json",
                 Route = self.Route,
                 BodyType = self.BodyType != EBodyType.DEFAULT ? self.BodyType : EBodyType.JSON,
                 Headers = GetHeaders(self.Headers),

--- a/src/FinalRest.core/FinalRest.core.csproj
+++ b/src/FinalRest.core/FinalRest.core.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://github.com/bPoller2810/FinalRest</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bPoller2810/FinalRest</RepositoryUrl>
     <PackageTags>c# rest post get put delete api</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FinalRest.core/HttpClient/DefaultHttpClient.cs
+++ b/src/FinalRest.core/HttpClient/DefaultHttpClient.cs
@@ -78,7 +78,7 @@ namespace FinalRest.core
             {
                 if (body is not null)
                 {
-                    content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+                    content = new StringContent(JsonSerializer.Serialize(body), request.Encoding, request.MediaType);
                 }
 
                 var result = await _httpClient.PostAsync(string.Concat(request.Route, urlParam), content);
@@ -102,7 +102,7 @@ namespace FinalRest.core
             {
                 if (body is not null)
                 {
-                    content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+                    content = new StringContent(JsonSerializer.Serialize(body), request.Encoding, request.MediaType);
                 }
 
                 var result = await _httpClient.PutAsync(string.Concat(request.Route, urlParam), content);

--- a/src/FinalRest.core/Request/FinalRestRequest.cs
+++ b/src/FinalRest.core/Request/FinalRestRequest.cs
@@ -1,8 +1,12 @@
-﻿namespace FinalRest.core
+﻿using System.Text;
+
+namespace FinalRest.core
 {
     public sealed class FinalRestRequest : IRestRequest
     {
         public ERestMethod Method { get; internal set; }
+        public Encoding Encoding { get; internal set; }
+        public string MediaType { get; internal set; }
 
         public string Route { get; internal set; }
 
@@ -26,6 +30,8 @@
             return new FinalRestRequest
             {
                 Method = Method,
+                Encoding = Encoding,
+                MediaType = MediaType,
                 Route = Route,
                 BodyType = BodyType,
 

--- a/src/FinalRest.core/Request/FinalRestRequestBuilder.cs
+++ b/src/FinalRest.core/Request/FinalRestRequestBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace FinalRest.core
@@ -14,6 +15,16 @@ namespace FinalRest.core
         /// On Build this will default to ERestMethod.GET if not set
         /// </summary>
         internal ERestMethod Method { get; set; }
+
+        /// <summary>
+        /// The encoding used for StringContent bodies
+        /// </summary>
+        internal Encoding Encoding { get; set; }
+
+        /// <summary>
+        /// The MediaType for StringContent bodies
+        /// </summary>
+        internal string MediaType { get; set; }
 
         /// <summary>
         /// The Route to the called Endpoint

--- a/src/FinalRest.core/Request/IRestRequest.cs
+++ b/src/FinalRest.core/Request/IRestRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 
 namespace FinalRest.core
 {
@@ -6,6 +7,8 @@ namespace FinalRest.core
     {
 
         ERestMethod Method { get; }
+        Encoding Encoding { get; }
+        string MediaType { get; }
         string Route { get; }
         EBodyType BodyType { get; }
 


### PR DESCRIPTION
Encoding and MediaType are hardcoded. This is bad. They should be optional Parameters and Default to the used Hardcoded values